### PR TITLE
Rename workflows to match conventions

### DIFF
--- a/.github/workflows/compile_python_requirements_and_create_pr.yml
+++ b/.github/workflows/compile_python_requirements_and_create_pr.yml
@@ -1,4 +1,4 @@
-name: Update Dependencies
+name: Compile python requirements and create PR
 
 on:
   push:

--- a/.github/workflows/test_and_lint_python_package.yml
+++ b/.github/workflows/test_and_lint_python_package.yml
@@ -1,3 +1,5 @@
+name: Test and lint python package
+
 on:
   push:
     branches:
@@ -6,6 +8,10 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
   test-and-lint:


### PR DESCRIPTION
## Summary
- Rename `pythonpackage.yml` → `test_and_lint_python_package.yml` to match the standard name used across all repos
- Rename `compile_requirements.yml` → `compile_python_requirements_and_create_pr.yml` to match armada conventions
- Add `name:`, `workflow_dispatch:`, and `permissions: contents: read` to the test workflow