### PR TITLE
Add missing workflows and release notes configuration

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,17 @@
+changelog:
+  categories:
+    - title: Breaking Changes 🛠
+      labels:
+        - breaking-change
+    - title: New Features 🎉
+      labels:
+        - feature
+    - title: Improvements
+      labels:
+        - improvement
+    - title: Bug Fixes
+      labels:
+        - bug
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/execute_stale_labeler.yml
+++ b/.github/workflows/execute_stale_labeler.yml
@@ -1,0 +1,17 @@
+name: Execute stale labeler
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "35 6 * * *"
+
+permissions:
+  contents: read
+  actions: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  labels:
+    uses: equinor/armada/.github/workflows/mark_issues_and_prs_as_stale.yml@main
+    secrets:
+      STALE_ISSUE_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/synchronize_labels.yml
+++ b/.github/workflows/synchronize_labels.yml
@@ -1,0 +1,13 @@
+name: Execute label synchronization
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  labels:
+    uses: equinor/armada/.github/workflows/synchronize_labels.yml@main
+    secrets:
+      LABEL_SYNC_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Add label synchronization workflow (calls armada reusable workflow)
- Add stale labeler workflow (daily cron + manual dispatch)
- Add release notes configuration for auto-generated changelogs